### PR TITLE
[2주차 과제] 장바구니 Thread 기능 및 MenuItem 재고와 동시성 Lock 추가

### DIFF
--- a/Sep.09/src/main/java/Main.java
+++ b/Sep.09/src/main/java/Main.java
@@ -3,6 +3,7 @@ import common.io.OutputWriter;
 import menu.MenuItem;
 import menu.Menu;
 import ordering.Order;
+import ordering.OrderPayResult;
 import ordering.ShoppingCart;
 import common.message.GuidanceMessage;
 import ui.OrderProgressDisplay;
@@ -109,10 +110,19 @@ public class Main {
             int amount = touchScreen.inputNaturalNumber();
 
             try {
-                int change = order.pay(amount, touchScreen);
-                touchScreen.show(GuidanceMessage.RETURN_CHANGE_AMOUNT.getText() + " : " + change);
+                OrderPayResult result = order.pay(amount);
 
-                break;
+                if (result.isInsufficientStock()) {
+                    touchScreen.show(String.format(GuidanceMessage.REMOVE_INSUFFICIENT_ITEMS_AND_PAY.getText(), result.getInsufficientItems()));
+                } else if (result.isEmptyCart()) {
+                    touchScreen.show(
+                            String.format(GuidanceMessage.REMOVE_INSUFFICIENT_ITEMS_AND_PAY.getText(), result.getInsufficientItems()) + "\n" +
+                                    GuidanceMessage.NO_ITEMS_TO_CHECKOUT.getText());
+                }
+
+                touchScreen.show(GuidanceMessage.RETURN_CHANGE_AMOUNT.getText() + " : " + result.getChange());
+                return;
+
             } catch (IllegalArgumentException e) {
                 touchScreen.show(e);
             }

--- a/Sep.09/src/main/java/Main.java
+++ b/Sep.09/src/main/java/Main.java
@@ -104,13 +104,12 @@ public class Main {
     }
 
     private static void checkout(TouchScreen touchScreen, Order order) {
-        touchScreen.show(GuidanceMessage.ENTER_MONEY.getText());
-
         while (true) {
+            touchScreen.show(GuidanceMessage.ENTER_MONEY.getText());
             int amount = touchScreen.inputNaturalNumber();
 
             try {
-                int change = order.pay(amount);
+                int change = order.pay(amount, touchScreen);
                 touchScreen.show(GuidanceMessage.RETURN_CHANGE_AMOUNT.getText() + " : " + change);
 
                 break;

--- a/Sep.09/src/main/java/Main.java
+++ b/Sep.09/src/main/java/Main.java
@@ -5,6 +5,7 @@ import menu.Menu;
 import ordering.Order;
 import ordering.ShoppingCart;
 import common.message.GuidanceMessage;
+import ui.OrderProgressDisplay;
 import ui.TouchScreen;
 
 import static java.lang.System.exit;
@@ -21,6 +22,10 @@ public class Main {
             ShoppingCart shoppingCart = new ShoppingCart();
             Order order = new Order(shoppingCart);
 
+            OrderProgressDisplay orderDisplay = new OrderProgressDisplay(touchScreen, order);
+            Thread orderProgressThread = new Thread(orderDisplay);
+            orderProgressThread.start();
+
             touchScreen.show(GuidanceMessage.WELCOME_MESSAGE.getText());
             touchScreen.show(GuidanceMessage.YOU_SHOULD_ENTER_CHOICE_NUMBER.getText());
 
@@ -32,9 +37,9 @@ public class Main {
                 chooseMoreMenu(touchScreen, menu, shoppingCart);
             }
 
-            touchScreen.show(order.getBill());
             checkout(touchScreen, order);
 
+            orderDisplay.stop();
             touchScreen.show(GuidanceMessage.THANK_YOU_FOR_USING.getText());
             sleep(2);
         }

--- a/Sep.09/src/main/java/common/message/GuidanceMessage.java
+++ b/Sep.09/src/main/java/common/message/GuidanceMessage.java
@@ -11,6 +11,7 @@ public enum GuidanceMessage {
     INSUFFICIENT_AMOUNT_TO_PAY("결제하기에 부족한 금액입니다."),
     RETURN_CHANGE_AMOUNT("거스름돈을 드리겠습니다."),
     WE_SHOW_LIVE_SHOPPING_LIST("선택하신 메뉴는 화면에 실시간으로 표시됩니다."),
+    REMOVE_INSUFFICIENT_ITEMS_AND_PAY("%s 품목은 수량 부족으로 구매가 불가능합니다. 이를 제외하고 결제를 진행합니다."),
 
     // Error Message
     YOU_SHOULD_INPUT_INTEGER("숫자를 입력해주세요."),
@@ -18,7 +19,7 @@ public enum GuidanceMessage {
     YOU_SHOULD_INPUT_RIGHT_RANGE_MENU_NUMBER("올바른 메뉴의 숫자를 입력해주세요."),
     IT_IS_NOT_MAIN_DISH("메인 메뉴를 선택해주세요."),
     YOU_SHOULD_INPUT_ENOUGH_TO_PAY("결제 가능한 금액을 입력해주세요."),
-
+    NO_ITEMS_TO_CHECKOUT("구매할 품목이 없습니다."),
 
 
     ;

--- a/Sep.09/src/main/java/common/message/GuidanceMessage.java
+++ b/Sep.09/src/main/java/common/message/GuidanceMessage.java
@@ -10,6 +10,7 @@ public enum GuidanceMessage {
     ENTER_MONEY("돈을 투입해주세요."),
     INSUFFICIENT_AMOUNT_TO_PAY("결제하기에 부족한 금액입니다."),
     RETURN_CHANGE_AMOUNT("거스름돈을 드리겠습니다."),
+    WE_SHOW_LIVE_SHOPPING_LIST("선택하신 메뉴는 화면에 실시간으로 표시됩니다."),
 
     // Error Message
     YOU_SHOULD_INPUT_INTEGER("숫자를 입력해주세요."),

--- a/Sep.09/src/main/java/menu/Menu.java
+++ b/Sep.09/src/main/java/menu/Menu.java
@@ -8,13 +8,13 @@ public class Menu {
     private final List<MenuItem> menuItems;
 
     private Menu() {
-        menuItems = List.of(new MenuItem("데이터", 1, MenuType.Dummy), // 리스트 1부터 시작을 위한 더미데이터
-                new MenuItem("빅맥", 5000, MenuType.MainDish), new MenuItem("치즈버거", 2000, MenuType.MainDish),
-                new MenuItem("싸이버거", 4000, MenuType.MainDish), new MenuItem("와퍼", 4500, MenuType.MainDish),
-                new MenuItem("콜라", 1000, MenuType.Beverage), new MenuItem("사이다", 1000, MenuType.Beverage),
-                new MenuItem("제로콜라", 1500, MenuType.Beverage), new MenuItem("제로사이다", 1500, MenuType.Beverage),
-                new MenuItem("감자튀김", 1000, MenuType.SideDish), new MenuItem("치킨너겟", 2000, MenuType.SideDish),
-                new MenuItem("코울슬로", 2500, MenuType.SideDish), new MenuItem("치즈스틱", 1500, MenuType.SideDish)
+        menuItems = List.of(new MenuItem("데이터", 1, MenuType.Dummy, 0), // 리스트 1부터 시작을 위한 더미데이터
+                new MenuItem("빅맥", 5000, MenuType.MainDish, 2), new MenuItem("치즈버거", 2000, MenuType.MainDish, 8),
+                new MenuItem("싸이버거", 4000, MenuType.MainDish, 10), new MenuItem("와퍼", 4500, MenuType.MainDish, 12),
+                new MenuItem("콜라", 1000, MenuType.Beverage, 8), new MenuItem("사이다", 1000, MenuType.Beverage, 14),
+                new MenuItem("제로콜라", 1500, MenuType.Beverage, 12), new MenuItem("제로사이다", 1500, MenuType.Beverage, 6),
+                new MenuItem("감자튀김", 1000, MenuType.SideDish, 6), new MenuItem("치킨너겟", 2000, MenuType.SideDish, 6),
+                new MenuItem("코울슬로", 2500, MenuType.SideDish, 10), new MenuItem("치즈스틱", 1500, MenuType.SideDish, 3)
         );
     }
 

--- a/Sep.09/src/main/java/menu/MenuItem.java
+++ b/Sep.09/src/main/java/menu/MenuItem.java
@@ -6,11 +6,13 @@ public class MenuItem {
     private final String name;
     private final int price;
     private final MenuType type;
+    private final Stock stock;
 
-    protected MenuItem(String name, int price, MenuType type) {
+    protected MenuItem(String name, int price, MenuType type, int initStock) {
         this.name = name;
         this.price = price;
         this.type = type;
+        this.stock = new Stock(initStock);
     }
 
     public String getInfo() {
@@ -35,6 +37,22 @@ public class MenuItem {
 
     public boolean isSideDish() {
         return this.type == MenuType.SideDish;
+    }
+
+    public boolean isEnoughStock(int needed) {
+        return this.stock.isMoreThan(needed);
+    }
+
+    public void sell(int purchaseQuantity) {
+        stock.decrease(purchaseQuantity);
+    }
+
+    public boolean isSoldOut() {
+        return this.stock.isSoldOut();
+    }
+
+    public int getStock() {
+        return stock.getQuantity();
     }
 
     @Override

--- a/Sep.09/src/main/java/menu/Stock.java
+++ b/Sep.09/src/main/java/menu/Stock.java
@@ -4,7 +4,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 public class Stock {
-    private volatile int quantity;
+    private int quantity;
 
     private final Lock lock = new ReentrantLock();
 

--- a/Sep.09/src/main/java/menu/Stock.java
+++ b/Sep.09/src/main/java/menu/Stock.java
@@ -1,0 +1,45 @@
+package menu;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class Stock {
+    private volatile int quantity;
+
+    private final Lock lock = new ReentrantLock();
+
+    public Stock(int quantity) {
+        this.quantity = quantity;
+    }
+
+    public boolean isMoreThan(int needed) {
+        lock.lock();
+        try {
+            return quantity >= needed;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void decrease(int purchaseQuantity) {
+        lock.lock();
+        try {
+            this.quantity -= purchaseQuantity;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public boolean isSoldOut() {
+        return quantity == 0;
+    }
+
+    public int getQuantity() {
+        lock.lock();
+        try {
+            return quantity;
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/Sep.09/src/main/java/ordering/Order.java
+++ b/Sep.09/src/main/java/ordering/Order.java
@@ -1,6 +1,11 @@
 package ordering;
 
 import common.message.GuidanceMessage;
+import ui.TouchScreen;
+
+import java.util.List;
+
+import static common.message.GuidanceMessage.REMOVE_INSUFFICIENT_ITEMS_AND_PAY;
 
 public class Order {
     private static final String BILL_FORMAT = """
@@ -28,8 +33,24 @@ public class Order {
         return shoppingCart.getTotalPrice();
     }
 
-    public int pay(int paidAmount) {
+    public int pay(int paidAmount, TouchScreen touchScreen) {
         validateEnoughToPay(paidAmount);
+
+        if (shoppingCart.isRemainingInStock()) {
+            shoppingCart.purchase();
+        } else {
+            List<String> soldOutItemNames = shoppingCart.removeInsufficientItems();
+
+            if (shoppingCart.isEmpty()) {
+                touchScreen.show(
+                        String.format(REMOVE_INSUFFICIENT_ITEMS_AND_PAY.getText(), soldOutItemNames) + "\n" +
+                        GuidanceMessage.NO_ITEMS_TO_CHECKOUT.getText());
+                return paidAmount;
+            }
+
+            touchScreen.show(String.format(REMOVE_INSUFFICIENT_ITEMS_AND_PAY.getText(), soldOutItemNames));
+            shoppingCart.purchase();
+        }
 
         return returnChange(paidAmount);
     }

--- a/Sep.09/src/main/java/ordering/Order.java
+++ b/Sep.09/src/main/java/ordering/Order.java
@@ -24,6 +24,10 @@ public class Order {
         return String.format(BILL_FORMAT, shoppingCart.getBillFormat(), shoppingCart.getTotalPrice());
     }
 
+    public int getTotalPrice() {
+        return shoppingCart.getTotalPrice();
+    }
+
     public int pay(int paidAmount) {
         validateEnoughToPay(paidAmount);
 

--- a/Sep.09/src/main/java/ordering/Order.java
+++ b/Sep.09/src/main/java/ordering/Order.java
@@ -1,11 +1,7 @@
 package ordering;
 
 import common.message.GuidanceMessage;
-import ui.TouchScreen;
-
 import java.util.List;
-
-import static common.message.GuidanceMessage.REMOVE_INSUFFICIENT_ITEMS_AND_PAY;
 
 public class Order {
     private static final String BILL_FORMAT = """
@@ -33,26 +29,22 @@ public class Order {
         return shoppingCart.getTotalPrice();
     }
 
-    public int pay(int paidAmount, TouchScreen touchScreen) {
+    public OrderPayResult pay(int paidAmount) {
         validateEnoughToPay(paidAmount);
 
         if (shoppingCart.isRemainingInStock()) {
             shoppingCart.purchase();
+            return OrderPayResult.success(returnChange(paidAmount));
         } else {
-            List<String> soldOutItemNames = shoppingCart.removeInsufficientItems();
+            List<String> removedItemNames = shoppingCart.removeInsufficientItems();
 
             if (shoppingCart.isEmpty()) {
-                touchScreen.show(
-                        String.format(REMOVE_INSUFFICIENT_ITEMS_AND_PAY.getText(), soldOutItemNames) + "\n" +
-                        GuidanceMessage.NO_ITEMS_TO_CHECKOUT.getText());
-                return paidAmount;
+                return new OrderPayResult(OrderStatus.EMPTY_CART, paidAmount, removedItemNames);
             }
 
-            touchScreen.show(String.format(REMOVE_INSUFFICIENT_ITEMS_AND_PAY.getText(), soldOutItemNames));
             shoppingCart.purchase();
+            return new OrderPayResult(OrderStatus.INSUFFICIENT_STOCK, returnChange(paidAmount), removedItemNames);
         }
-
-        return returnChange(paidAmount);
     }
 
     private void validateEnoughToPay(int paidAmount) {

--- a/Sep.09/src/main/java/ordering/OrderPayResult.java
+++ b/Sep.09/src/main/java/ordering/OrderPayResult.java
@@ -1,0 +1,39 @@
+package ordering;
+
+import java.util.List;
+
+public class OrderPayResult {
+    private final OrderStatus orderStatus;
+    private final int change;
+    private final List<String> insufficientItems;
+
+    public OrderPayResult(OrderStatus orderStatus, int change, List<String> insufficientItems) {
+        this.orderStatus = orderStatus;
+        this.change = change;
+        this.insufficientItems = insufficientItems;
+    }
+
+    public static OrderPayResult success(int change) {
+        return new OrderPayResult(OrderStatus.SUCCESS, change, List.of());
+    }
+
+    public OrderStatus getStatus() {
+        return this.orderStatus;
+    }
+
+    public int getChange() {
+        return this.change;
+    }
+
+    public List<String> getInsufficientItems() {
+        return insufficientItems;
+    }
+
+    public boolean isInsufficientStock() {
+        return this.orderStatus == OrderStatus.INSUFFICIENT_STOCK;
+    }
+
+    public boolean isEmptyCart() {
+        return this.orderStatus == OrderStatus.EMPTY_CART;
+    }
+}

--- a/Sep.09/src/main/java/ordering/OrderStatus.java
+++ b/Sep.09/src/main/java/ordering/OrderStatus.java
@@ -1,0 +1,8 @@
+package ordering;
+
+public enum OrderStatus {
+    SUCCESS,
+    INSUFFICIENT_STOCK,
+    EMPTY_CART,
+    ;
+}

--- a/Sep.09/src/main/java/ordering/ShoppingCart.java
+++ b/Sep.09/src/main/java/ordering/ShoppingCart.java
@@ -2,7 +2,9 @@ package ordering;
 
 import menu.MenuItem;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 public class ShoppingCart {
@@ -35,5 +37,44 @@ public class ShoppingCart {
         }
 
         return sb.toString();
+    }
+
+    public boolean isRemainingInStock() {
+        return pickedMenus.entrySet().stream()
+                .allMatch(entry -> {
+                    int quantity = entry.getValue();
+                    return entry.getKey().isEnoughStock(quantity);
+                });
+    }
+
+    public void purchase() {
+        pickedMenus.forEach((menuItem, quantity) -> menuItem.sell(quantity));
+    }
+
+    public List<String> removeInsufficientItems() {
+        List<String> removedItems = new ArrayList<>();
+
+        for (var entry : pickedMenus.entrySet()) {
+            MenuItem item = entry.getKey();
+            Integer buyingQuantity = entry.getValue();
+
+            if (item.isEnoughStock(buyingQuantity)) {
+                continue;
+            }
+
+            if (item.isSoldOut()) {
+                removedItems.add(item.getName());
+                pickedMenus.remove(item);
+            } else {
+                removedItems.add(item.getName());
+                pickedMenus.put(item, item.getStock());
+            }
+        }
+
+        return removedItems;
+    }
+
+    public boolean isEmpty() {
+        return pickedMenus.isEmpty();
     }
 }

--- a/Sep.09/src/main/java/ordering/ShoppingCart.java
+++ b/Sep.09/src/main/java/ordering/ShoppingCart.java
@@ -64,7 +64,7 @@ public class ShoppingCart {
 
             if (item.isSoldOut()) {
                 removedItems.add(item.getName());
-                pickedMenus.remove(item);
+                pickedMenus.put(item, 0);
             } else {
                 removedItems.add(item.getName());
                 pickedMenus.put(item, item.getStock());

--- a/Sep.09/src/main/java/ordering/ShoppingCart.java
+++ b/Sep.09/src/main/java/ordering/ShoppingCart.java
@@ -76,6 +76,11 @@ public class ShoppingCart {
     }
 
     public boolean isEmpty() {
-        return pickedMenus.isEmpty();
+        if (pickedMenus.isEmpty()) {
+            return true;
+        }
+
+        return pickedMenus.values().stream()
+                .allMatch(quantity -> quantity == 0);
     }
 }

--- a/Sep.09/src/main/java/ordering/ShoppingCart.java
+++ b/Sep.09/src/main/java/ordering/ShoppingCart.java
@@ -3,6 +3,7 @@ package ordering;
 import menu.MenuItem;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -11,7 +12,7 @@ public class ShoppingCart {
     private final Map<MenuItem, Integer> pickedMenus;
 
     public ShoppingCart() {
-        this.pickedMenus = new LinkedHashMap<>();
+        this.pickedMenus = Collections.synchronizedMap(new LinkedHashMap<>());
     }
 
     public void add(MenuItem menu) {

--- a/Sep.09/src/main/java/ui/OrderProgressDisplay.java
+++ b/Sep.09/src/main/java/ui/OrderProgressDisplay.java
@@ -1,0 +1,43 @@
+package ui;
+
+import common.message.GuidanceMessage;
+import ordering.Order;
+
+public class OrderProgressDisplay implements Runnable {
+    private final TouchScreen touchScreen;
+    private final Order order;
+
+    private volatile boolean running;
+
+    public OrderProgressDisplay(TouchScreen touchScreen, Order order) {
+        this.touchScreen = touchScreen;
+        this.order = order;
+        this.running = true;
+    }
+
+    @Override
+    public void run() {
+        touchScreen.show(GuidanceMessage.WE_SHOW_LIVE_SHOPPING_LIST.getText());
+
+        String previousBill = order.getBill();
+        while (running) {
+            String currentBill = order.getBill();
+
+            if (order.getTotalPrice() >= 0 && !currentBill.equals(previousBill)) {
+                touchScreen.show(currentBill);
+                previousBill = currentBill;
+            }
+
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+    }
+
+    public void stop() {
+        this.running = false;
+    }
+}

--- a/Sep.09/src/main/java/ui/OrderProgressDisplay.java
+++ b/Sep.09/src/main/java/ui/OrderProgressDisplay.java
@@ -23,7 +23,7 @@ public class OrderProgressDisplay implements Runnable {
         while (running) {
             String currentBill = order.getBill();
 
-            if (order.getTotalPrice() >= 0 && !currentBill.equals(previousBill)) {
+            if (order.getTotalPrice() > 0 && !currentBill.equals(previousBill)) {
                 touchScreen.show(currentBill);
                 previousBill = currentBill;
             }


### PR DESCRIPTION
* 기본 thread 활용 기능 [09fbeed317323ea4b45bb4767bc504b5011e2b8f] : 장바구니 목록을 변경할 때마다 실시간으로 화면에 띄우게 함으로써 사용자가 추가한 메뉴 리스트를 지속적으로 확인할 수 있게 되었습니다. 

* `MenuItem`에 *Stock*을 추가했습니다. 각 메뉴 아이템은 재고를 가지게 되었고 이 재고는 Menu 생성자에서 명시적으로 전달합니다.

* *Order* 클래스의 `pay()` 메서드에서 재고를 확인 후 구매 로직을 진행합니다.
    * 재고가 충분하다면 그대로 구매를 진행합니다.
    * 부족하다면 부족한 품목을 제외하고 구매합니다.
    * 부족한 품목을 제거했을 때 쇼핑 카트에 비어있으면 그대로 쇼핑을 종료합니다.

* 회고는 노션에 작성하겠습니다.